### PR TITLE
SD-334: Make OrganizationJobs repo private

### DIFF
--- a/SimeonInstaller.ps1
+++ b/SimeonInstaller.ps1
@@ -995,7 +995,7 @@ CRLFOption=CRLFAlways
         }
 
         if (!$repo.defaultBranch -and $GetSourceUrl) {
-            Push-Location (Get-GitRepository (. $GetSourceUrl))
+            Push-Location (Get-GitRepository (. $GetSourceUrl) -AccessToken $env:GITHUB_TOKEN)
             try {
                 if ($ClearRepositoryContentsOnCreate) {
                     # delete Source/Resources/Content


### PR DESCRIPTION
This PR addresses SD-334 which requests that we make OrganizationJobs private. In order to do this, we need to modify the Simeon Installer script to authenticate to GitHub when cloning the repos.