### PR TITLE
FIX: Add environment permissions handling to SimeonInstaller

### DIFF
--- a/SimeonInstaller.ps1
+++ b/SimeonInstaller.ps1
@@ -1903,6 +1903,14 @@ CRLFOption=CRLFAlways
             Write-Information "Approval does not exist - no change is required"
         }
 
+        $environmentPermissionsUrl = "$apiBaseUrl/pipelines/pipelinepermissions/environment/$($environment.id)"
+        Invoke-WithRetry { Invoke-RestMethod @restProps -Uri $environmentPermissionsUrl -Method Patch -Body @"
+        {
+            "resource":{"type":"environment","id":"$($environment.id)"},
+            "pipelines":[],
+            "allPipelines":{"authorized":true,"authorizedBy":null,"authorizedOn":null}
+        }
+"@ } | Out-Null
     }
 
     <#

--- a/SimeonInstaller.ps1
+++ b/SimeonInstaller.ps1
@@ -1903,6 +1903,7 @@ CRLFOption=CRLFAlways
             Write-Information "Approval does not exist - no change is required"
         }
 
+        # Allow pipeline to use environment
         $environmentPermissionsUrl = "$apiBaseUrl/pipelines/pipelinepermissions/environment/$($environment.id)"
         Invoke-WithRetry { Invoke-RestMethod @restProps -Uri $environmentPermissionsUrl -Method Patch -Body @"
         {


### PR DESCRIPTION
This PR adds support for automatically fixing environment permissions for pipelines.

**Background:**
Recently Microsoft made a change to environment creation that prevented pipelines from accessing the environment by default. This PR fixes that by automatically allowing pipeline access to the environment.